### PR TITLE
fix(ui): improve layout by removing double scrollbars and adjusting heading spacing

### DIFF
--- a/apps/docs/src/app/(home)/offers.tsx
+++ b/apps/docs/src/app/(home)/offers.tsx
@@ -104,7 +104,7 @@ export function Offers() {
 					/>
 				))}
 			</BentoGrid>
-			<h2 className="text-center text-2xl font-bold mt-15">And more!</h2>
+			<h2 className="text-center text-2xl font-bold py-16">And more!</h2>
 		</div>
 	);
 }

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -13,8 +13,8 @@ export default function HomePage() {
 		<main className="w-screen h-screen relative overflow-hidden">
 			<BackgroundBeams className="absolute inset-0 w-full h-full" />
 
-			<div className="w-full absolute inset-0 h-screen overflow-y-auto">
-				<div className="w-full mt-16 overflow-y-auto h-screen">
+			<div className="w-full absolute pt-16 inset-0 h-screen overflow-y-auto">
+				<div className="w-full ">
 					<BetaWarning />
 					<Hero />
 					<Callout />


### PR DESCRIPTION
This PR introduces UI refinements aimed at improving the overall layout and scrolling behavior:

### Changes Made:
* Removed double scrollbars:
  * Simplified the container structure by removing redundant `overflow-y-auto` and `h-screen`.
  * Added `pt-16` to the main container to maintain proper spacing without causing nested scroll areas.

* Adjusted "And more!" heading spacing:
  * Replaced `mt-15` with `py-16` for improved vertical spacing and visual balance.


### Why These Changes Are Needed:

* Prevents redundant scrollbars that create a poor user experience.
* Enhances the visual hierarchy and spacing of the "And more!" heading for better readability.

### Screenshots 

Before :
<img width="1317" height="638" alt="image" src="https://github.com/user-attachments/assets/f3f4f84a-af17-4bfc-865e-b3c1c88fcb05" />


After : 
<img width="1312" height="638" alt="image" src="https://github.com/user-attachments/assets/cb9d6530-2b09-4804-955d-a968d2ec303b" />


Before :
<img width="1307" height="198" alt="image" src="https://github.com/user-attachments/assets/f9df0889-9278-4043-adf7-5a417c1d5e0d" />

After :
<img width="1254" height="241" alt="image" src="https://github.com/user-attachments/assets/4779af1f-5e88-49ce-b1a6-5156e9f883f5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout spacing for the "And more!" heading in the Offers section for improved visual consistency.
  * Simplified the main content container structure on the home page, consolidating scroll and spacing behavior for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->