### PR TITLE
feat: implement `last-social-provider`

### DIFF
--- a/packages/plugins/app-invite/build.ts
+++ b/packages/plugins/app-invite/build.ts
@@ -2,6 +2,6 @@ import { build, type Config } from "@better-auth-kit/internal-build";
 
 export const config: Config = {
 	enableDts: true,
-	entrypoints: ['./src/index.ts', './src/client.ts'],
+	entrypoints: ["./src/index.ts", "./src/client.ts"],
 };
 build(config);

--- a/packages/plugins/last-social-provider/.gitignore
+++ b/packages/plugins/last-social-provider/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.env
+.env.local
+node_modules
+dist

--- a/packages/plugins/last-social-provider/.npmignore
+++ b/packages/plugins/last-social-provider/.npmignore
@@ -1,0 +1,4 @@
+build-dev.ts
+build.ts
+.turbo
+src

--- a/packages/plugins/last-social-provider/LICENSE
+++ b/packages/plugins/last-social-provider/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2025 - present, frectonz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/plugins/last-social-provider/README.md
+++ b/packages/plugins/last-social-provider/README.md
@@ -1,0 +1,29 @@
+# Last Used Social Provider Plugin for [Better Auth](https://github.com/better-auth/better-auth)
+
+This plugin allows you to store the last social provider a user used to login.
+
+## Installation
+
+```bash
+npm install @better-auth-kit/last-social-provider
+```
+
+## Usage
+
+```ts
+import { lastSocialProvider } from "@better-auth-kit/last-social-provider";
+
+export const auth = betterAuth({
+  plugins: [
+    lastSocialProvider()
+  ],
+});
+```
+
+## Documentation
+
+Read our documentation at [better-auth-kit.com](https://better-auth-kit.com/docs/plugins/last-social-provider).
+
+## License
+
+[MIT](LICENSE)

--- a/packages/plugins/last-social-provider/build-dev.ts
+++ b/packages/plugins/last-social-provider/build-dev.ts
@@ -1,0 +1,4 @@
+import { buildDev } from "@better-auth-kit/internal-build";
+import { config } from "./build";
+
+buildDev(config);

--- a/packages/plugins/last-social-provider/build.ts
+++ b/packages/plugins/last-social-provider/build.ts
@@ -1,0 +1,6 @@
+import { build, type Config } from "@better-auth-kit/internal-build";
+
+export const config: Config = {
+	enableDts: true,
+};
+build(config);

--- a/packages/plugins/last-social-provider/package.json
+++ b/packages/plugins/last-social-provider/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@better-auth-kit/last-social-provider",
+	"version": "0.0.6",
+	"description": "A plugin for better-auth that stores the last social provider a user used to login.",
+	"type": "module",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ping-maxwell/better-auth-kit"
+	},
+	"exports": {
+		".": {
+			"default": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"scripts": {
+		"dev": "bun build-dev.ts",
+		"build": "bun build.ts"
+	},
+	"keywords": ["better-auth", "social", "social-provider", "plugin"],
+	"author": "frectonz",
+	"license": "MIT",
+	"devDependencies": {
+		"@better-auth-kit/internal-build": "workspace:*"
+	},
+	"peerDependencies": {
+		"better-auth": "1.3"
+	},
+	"dependencies": {},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/plugins/last-social-provider/src/client.ts
+++ b/packages/plugins/last-social-provider/src/client.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "better-auth";
-import type { lastSocialProvider } from ".";
+import { lastSocialProvider } from ".";
 
 export const lastSocialProviderClient = () => {
 	return {

--- a/packages/plugins/last-social-provider/src/client.ts
+++ b/packages/plugins/last-social-provider/src/client.ts
@@ -1,0 +1,9 @@
+import type { BetterAuthClientPlugin } from "better-auth";
+import type { lastSocialProvider } from ".";
+
+export const lastSocialProviderClient = () => {
+	return {
+		id: "last-social-provider",
+		$InferServerPlugin: {} as ReturnType<typeof lastSocialProvider>,
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/plugins/last-social-provider/src/index.ts
+++ b/packages/plugins/last-social-provider/src/index.ts
@@ -50,7 +50,7 @@ export const lastSocialProvider = (options?: LastSocialProviderOptions) => {
 					const providerId = c.getCookie(opts.cookieName);
 
 					if (!providerId) {
-						throw new APIError("NOT_FOUND");
+						return null;
 					}
 
 					return providerId as SocialProvider;

--- a/packages/plugins/last-social-provider/src/index.ts
+++ b/packages/plugins/last-social-provider/src/index.ts
@@ -1,0 +1,79 @@
+import { APIError, type BetterAuthPlugin } from "better-auth";
+import type { SocialProvider } from "better-auth/social-providers";
+import { createAuthEndpoint, createAuthMiddleware } from "better-auth/api";
+
+import type {
+	LastSocialProviderOptions,
+	RealizedLastSocialProviderOptions,
+} from "./types";
+
+export * from "./types";
+export * from "./client";
+
+export const lastSocialProvider = (options?: LastSocialProviderOptions) => {
+	const opts: RealizedLastSocialProviderOptions = {
+		cookieName: options?.cookieName ?? "better-auth.last_used_social",
+		maxAge: options?.maxAge ?? 432000,
+	};
+
+	return {
+		id: "last-social-provider",
+		endpoints: {
+			lastUsedSocialProvider: createAuthEndpoint(
+				"/last-used-social-provider",
+				{
+					method: "GET",
+					requireHeaders: true,
+					metadata: {
+						openapi: {
+							description:
+								"Get the last social provider the user used to sign in.",
+							operationId: "lastUsedSocialProvider",
+							responses: {
+								"200": {
+									description:
+										"Success - Returns the provider ID of the last social provider",
+									content: {
+										"application/json": {
+											schema: {
+												type: "string",
+												description: "Social Provider ID",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (c) => {
+					const providerId = c.getCookie(opts.cookieName);
+
+					if (!providerId) {
+						throw new APIError("NOT_FOUND");
+					}
+
+					return providerId as SocialProvider;
+				},
+			),
+		},
+		hooks: {
+			after: [
+				{
+					matcher: (context) => {
+						return context.path.startsWith("/callback");
+					},
+
+					handler: createAuthMiddleware(async (ctx) => {
+						const providerId = ctx.path.split("/").at(-1);
+						if (!providerId) return;
+
+						ctx.setCookie(opts.cookieName, providerId, {
+							maxAge: opts.maxAge,
+						});
+					}),
+				},
+			],
+		},
+	} satisfies BetterAuthPlugin;
+};

--- a/packages/plugins/last-social-provider/src/types.ts
+++ b/packages/plugins/last-social-provider/src/types.ts
@@ -1,0 +1,19 @@
+export type LastSocialProviderOptions = {
+	/**
+	 * The name of the last used social provider cookie.
+	 *
+	 * @default "better-auth.last_used_social"
+	 */
+	cookieName?: string;
+	/**
+	 * The number of seconds until the cookie expires. A zero or
+	 * negative number will expire the cookie immediately. By default
+	 * the cookie lasts for 5 days.
+	 *
+	 * @default 432000
+	 */
+	maxAge?: number;
+};
+
+export type RealizedLastSocialProviderOptions =
+	Required<LastSocialProviderOptions>;

--- a/packages/plugins/last-social-provider/tsconfig.json
+++ b/packages/plugins/last-social-provider/tsconfig.json
@@ -1,0 +1,28 @@
+{
+	"compilerOptions": {
+		// Enable latest features
+		"lib": ["ESNext", "DOM"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"verbatimModuleSyntax": true,
+		"declaration": true,
+
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"include": ["./src/*"],
+	"exclude": ["dist", "build.ts"]
+}


### PR DESCRIPTION
This was originally supposed to be a feature in `better-auth` itself (https://github.com/better-auth/better-auth/pull/3566), but we have decided that it wouldn’t really be a good fit in the core library. (https://github.com/better-auth/better-auth/pull/3566#issuecomment-3111983799)

So I thought it would be good if it was part of `better-auth-kit` instead. What do you think?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Last Used Social Provider" plugin to record the last social login provider, set it via a post-login hook, and expose it through a GET endpoint.

* **Documentation**
  * Added README with installation, usage example, and license details.

* **Chores**
  * Added package metadata, build/dev scripts, TypeScript config, license, and updated Git/npm ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->